### PR TITLE
适配国服

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
  本插件用于解除中国客户端上，取消对已经被禁止的插件使用。
 
 ## 如何使用
+- 找到卫月资产文件`dalamudAssets`,一般为`%Appdata%/XIVLauncherCN/dalamudAssets`
+- 在`UnbanPluginsCN.exe`同目录创建`path.config`,并将上一步中找到的目录填写进去。
 - 在启动游戏或者启动卫月之前运行UnbanPluginsCN.exe。
 - 启动成功后你所有的插件都能正常加载了。
 


### PR DESCRIPTION
# 适配国服启动器

国服使用`XIVLauncherCN`不会调用`Dalamud.Updater`进行更新,进行了修改以适配`XIVLauncherCN`,同时,国服启用`bannedplugin.json`进行插件禁用,一同进行了修改

目前由于`XIVLauncherCN`不调用`Dalamud.Updater`,无法使用`process`获取进程目录,使用`path.config`进行配置,由用户进行目录的检索,并对此进行修改

# 可能存在的问题

由于我不使用`Dalamud`,无法测试直接由`Dalamud.updater`启动的情况

由用户设置配置文件可能会出现一些问题,例如用户会遗忘,无法检索到目标目录等.是否有更好的解决方案?

# ---------Translate By Coplit-----------
# Adapting to the Chinese Server Launcher

The Chinese server uses `XIVLauncherCN` and does not call `Dalamud.Updater` for updates. Modifications have been made to adapt to `XIVLauncherCN`. Additionally, the Chinese server uses `bannedplugin.json` for plugin disabling, which has also been modified.

Currently, since `XIVLauncherCN` does not call `Dalamud.Updater`, it is not possible to use `process` to get the process directory. Instead, `path.config` is used for configuration, allowing users to search for the directory and modify it accordingly.

# Potential Issues

Since I do not use `Dalamud`, I cannot test the situation where it is directly started by `Dalamud.updater`.

Having users set the configuration file may lead to some issues, such as users forgetting or being unable to locate the target directory. Is there a better solution?

#12 